### PR TITLE
Fix a typo in the name of a book

### DIFF
--- a/src/sections/backender.html
+++ b/src/sections/backender.html
@@ -25,7 +25,7 @@
               <div class="caption">Книги <span class="emoji">📖</span></div>
               <ul class="tutorials">
                 <li><a href="https://www.ozon.ru/context/detail/id/136880774/">Введение в базы данных</a></li>
-                <li><a href="https://www.ozon.ru/context/detail/id/19383907/">7 баз данных за 7 дней</a></li>
+                <li><a href="https://www.ozon.ru/context/detail/id/19383907/">7 баз данных за 7 недель</a></li>
                 <li><a href="https://www.ozon.ru/context/detail/id/28336354/">Чистый код</a></li>
                 <li><a href="https://www.ozon.ru/context/detail/id/8466390/">Читаемый код, или программирование как искусство</a></li>
                 <li><a href="https://www.ozon.ru/context/detail/id/26893656/">7 языков за 7 недель</a></li>


### PR DESCRIPTION
The actual name of the book is different: https://www.ozon.ru/context/detail/id/19383907/